### PR TITLE
Forward user arguments at the end of the gdb command

### DIFF
--- a/gdb.kak
+++ b/gdb.kak
@@ -74,7 +74,7 @@ def -params .. -file-completion gdb-session-new %{
             sleep 0.1
         done
     }
-    terminal %opt{gdb_program} %arg{@} --init-eval-command "set mi-async on" --init-eval-command "new-ui mi3 %opt{gdb_dir}/pty"
+    terminal %opt{gdb_program} --init-eval-command "set mi-async on" --init-eval-command "new-ui mi3 %opt{gdb_dir}/pty" %arg{@}
 }
 
 def rr-session-new %{


### PR DESCRIPTION
This fixes the `gdb-session-new --args <command> <params>...` use
case by ensuring the `--init-eval-command` parameters are handled
by gdb instead of forwarded to the underlying command.