### PR TITLE
Fix: mktemp option, make it work properly on Linux and FreeBSD.

### DIFF
--- a/gdb.kak
+++ b/gdb.kak
@@ -144,7 +144,7 @@ def -hidden gdb-session-start-receiver %{
             printf "fail '''socat'' and ''perl'' must be installed to use this plugin'"
             exit
         fi
-        export tmpdir=$(mktemp -t -d gdb_kak_XXX)
+        export tmpdir=$(mktemp -d --tmpdir gdb_kak_XXX)
         mkfifo "${tmpdir}/input_pipe"
         {
             output_handler="${kak_opt_gdb_script_path%/*}/gdb-output-handler.perl"


### PR DESCRIPTION
We use `mktemp` to make temporary directory.

`-t`: option have different semantics on Linux and FreeBSD, and has been marked as [deprecated] on Linux.
`--tmpdir`: option both work on Linux and FreeBSD. It will use $TMPDIR if set, else /tmp.

Other BSD may also work but I have not test.