### PR TITLE
Fix compatibility with Chimera Linux

### DIFF
--- a/gdb.kak
+++ b/gdb.kak
@@ -145,7 +145,7 @@ def -hidden gdb-session-start-receiver %{
             exit
         fi
         # make sure mktemp will use $TMPDIR if set or /tmp
-        export tmpdir=$(mktemp -d -p ${TMPDIR:-/tmp} gdb_kak_XXX);
+        export tmpdir=$(mktemp -d -p ${TMPDIR:-/tmp} gdb_kak_XXXXXX);
         mkfifo "${tmpdir}/input_pipe"
         mkfifo "${tmpdir}/helper_pipe"
         {


### PR DESCRIPTION
The FreeBSD mktemp implementation combined with musl's mktemp(),
mkdtemp(), etc. implementation requires at least six Xs. If fewer than
six Xs are present at the end of the template argument it fails with
"Invalid Argument."

This is reproducible on Chimera Linux. I'm not sure if there are any
standard POSIX requirements placed on mktemp here but I don't think
adding a few more Xs shouldn't cause problems.