### PR TITLE
Use gdb_program option also when invoking rr

### DIFF
--- a/gdb.kak
+++ b/gdb.kak
@@ -92,7 +92,7 @@ starts a new gdb session using 'rr replay'
         done
     }
     try %{
-        terminal rr replay -- --init-eval-command "set mi-async on" --init-eval-command "new-ui mi3 %opt{gdb_dir}/pty"
+        terminal rr replay --debugger %opt{gdb_program} -- --init-eval-command "set mi-async on" --init-eval-command "new-ui mi3 %opt{gdb_dir}/pty"
     } catch %{
         gdb-session-stop-receiver
         fail 'The ''terminal'' command must be defined to start a gdb session'


### PR DESCRIPTION
Hi!

This is a very simple PR to make `rr-session-new` take `gdb_program` option into account. Currently, only `gdb-session-new` looks at it.